### PR TITLE
COSA-1112: Adds meme and gif as utm content types

### DIFF
--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -37,6 +37,8 @@ class Share < ApplicationRecord
     Carousel
     Graphic
     Textonly
+    Meme
+    Gif
   ].sort!
 
   validates :utm_source, :utm_campaign, :utm_medium, :utm_term, presence: true


### PR DESCRIPTION
This PR adds meme and gif as utm content types, as requested. 

Jira ticket ID: https://ombulabs.atlassian.net/browse/COSA-1112
<img width="954" alt="Screen Shot 2023-05-11 at 10 43 48 AM" src="https://github.com/fastruby/librarian/assets/6892410/2597e60f-a750-4b5b-a0dc-8cce19f0f33d">
