### PR TITLE
COSA-1113: Don't allow Social Media Snippets to include urls

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -90,6 +90,6 @@ class Link < ApplicationRecord
 
   def gpt_prompt(social_media_site: "Twitter")
     "Please generate three social media snippets for #{social_media_site} using this article "\
-    "and make sure to include at least one relevant hashtag: #{self.url}"
+    "and make sure to include at least one relevant hashtag: #{self.url}. Don't add the url to the social media snippet."
   end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -90,6 +90,6 @@ class Link < ApplicationRecord
 
   def gpt_prompt(social_media_site: "Twitter")
     "Please generate three social media snippets for #{social_media_site} using this article "\
-    "and make sure to include at least one relevant hashtag: #{self.url}. Don't add the url to the social media snippet."
+    "and make sure to include at least one relevant hashtag: #{self.url}. Don't add the url to the social media snippets."
   end
 end


### PR DESCRIPTION
This PR fixes the following issue: https://ombulabs.atlassian.net/browse/COSA-1113

I edited the prompt to tell chat GPT not to include the URL in the snippets. Maybe a better solution would be searching and replacing any links, but I thought that could be overkill, since they don't always appear in the snippets. Let me know what you think.