### PR TITLE
COSA-1115: Move links above Social Media Snippets

### DIFF
--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -2,8 +2,20 @@
 
 <%= render @link %>
 
+<% if @link.shares.any? %>
+  <h2 class="text-4xl">Shares</h2>
+  <p class="my-3">Shortened links can be created to share in various advertising sources</p>
+
+  <ul class="link-shares mb-5">
+  <% @link.shares.find_each do |share| %>
+    <li class="<%= cycle("bg-slate-300", "bg-red-100") %>"><%= render share %><%= link_to "Clone", link_clone_path(@link, share) %></li>
+  <% end %>
+  </ul>
+<% end %>
+
 <% if @link.social_media_snippets.any? %>
   <h2 class="text-4xl">Social Media Snippets</h2>
+  <p class="my-3">These prompts are created by Open AI, and are suggestions to get you started when posting one of our blog posts, they should be paired with a link from above.</p>
 
   <% @grouped_social_media_snippets.each do |media_type, snippets| %>
     <h3 class="text-2xl"><%= media_type %></h3>
@@ -13,16 +25,6 @@
       <% end %>
     </ul>
   <% end %>
-<% end %>
-
-<% if @link.shares.any? %>
-  <h2 class="text-4xl">Shares</h2>
-
-  <ul class="link-shares">
-  <% @link.shares.find_each do |share| %>
-    <li class="<%= cycle("bg-slate-300", "bg-red-100") %>"><%= render share %><%= link_to "Clone", link_clone_path(@link, share) %></li>
-  <% end %>
-  </ul>
 <% end %>
 
 <div class="mb-6">

--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -2,14 +2,10 @@
 
 <%= render @link %>
 
+<h2 class="text-4xl">Shares  <%= link_to "New Share Link", new_link_share_path(@link), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-sm" %></h2>
+<p class="my-3">Shortened links can be created to share in various advertising sources.</p>
+
 <% if @link.shares.any? %>
-  <h2 class="text-4xl">Shares</h2>
-  <p class="my-3">Shortened links can be created to share in various advertising sources.</p>
-
-  <div class="mb-6 flex justify-end">
-    <%= link_to "New Share Link", new_link_share_path(@link) %>
-  </div>
-
   <ul class="link-shares mb-5">
   <% @link.shares.find_each do |share| %>
     <li class="<%= cycle("bg-slate-300", "bg-red-100") %>"><%= render share %><%= link_to "Clone", link_clone_path(@link, share) %></li>

--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -7,8 +7,7 @@
   <p class="my-3">Shortened links can be created to share in various advertising sources.</p>
 
   <div class="mb-6 flex justify-end">
-    <%= link_to "Back to links", links_path %> |
-    <%= link_to "Share", new_link_share_path(@link) %>
+    <%= link_to "New Share Link", new_link_share_path(@link) %>
   </div>
 
   <ul class="link-shares mb-5">

--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -6,6 +6,11 @@
   <h2 class="text-4xl">Shares</h2>
   <p class="my-3">Shortened links can be created to share in various advertising sources.</p>
 
+  <div class="mb-6 flex justify-end">
+    <%= link_to "Back to links", links_path %> |
+    <%= link_to "Share", new_link_share_path(@link) %>
+  </div>
+
   <ul class="link-shares mb-5">
   <% @link.shares.find_each do |share| %>
     <li class="<%= cycle("bg-slate-300", "bg-red-100") %>"><%= render share %><%= link_to "Clone", link_clone_path(@link, share) %></li>
@@ -26,8 +31,3 @@
     </ul>
   <% end %>
 <% end %>
-
-<div class="mb-6">
-  <%= link_to "Back to links", links_path %> |
-  <%= link_to "Share", new_link_share_path(@link) %>
-</div>

--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -4,7 +4,7 @@
 
 <% if @link.shares.any? %>
   <h2 class="text-4xl">Shares</h2>
-  <p class="my-3">Shortened links can be created to share in various advertising sources</p>
+  <p class="my-3">Shortened links can be created to share in various advertising sources.</p>
 
   <ul class="link-shares mb-5">
   <% @link.shares.find_each do |share| %>


### PR DESCRIPTION
<img width="1203" alt="Screen Shot 2023-05-15 at 12 51 59 PM" src="https://github.com/fastruby/librarian/assets/6892410/e2dfef6b-9b09-434d-9435-4da23607bfce">

This PR moves the order of the Shares and Snippets sections. It also adds some spacing and text to indicate what the sections are used for. Please see https://ombulabs.atlassian.net/browse/COSA-1115 for more info.