### PR TITLE
Fix the last migration to actually create the users table

### DIFF
--- a/db/migrate/20230516150928_add_auth_columns_to_user.rb
+++ b/db/migrate/20230516150928_add_auth_columns_to_user.rb
@@ -1,9 +1,0 @@
-class AddAuthColumnsToUser < ActiveRecord::Migration[7.0]
-  def change
-    change_table :users do |t|
-      t.string :provider
-      t.string :uid, unique: true
-      t.string :name
-    end
-  end
-end

--- a/db/migrate/20230516150928_create_users.rb
+++ b/db/migrate/20230516150928_create_users.rb
@@ -1,0 +1,18 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table "users", force: :cascade do |t|
+      t.string "email", default: "", null: false
+      t.string "encrypted_password", default: "", null: false
+      t.string "reset_password_token"
+      t.datetime "reset_password_sent_at"
+      t.datetime "remember_created_at"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.string "provider"
+      t.string "uid"
+      t.string "name"
+      t.index ["email"], name: "index_users_on_email", unique: true
+      t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    end
+  end
+end


### PR DESCRIPTION
At some point the schema.rb got out of sync with the migrations. Later, a migration was added to add fields to the users table.

Locally it was working because before doing that many of us were doing `rails db:schema:load` (or something that calls that) so the database table was created based on the schema, so then that new migration worked fine.

When ran in production, the users table does not exist, so the new migration was failing.

Reloading the schema is not possible in production since it will clear the whole DB.

Instead, this PR changes the last PR that was adding the fields to actually create the table with the resulting schema, so it can be run in production without losing data, and it should not impact development/staging since that migration already ran there (and those environment can always be reset if needed)