### PR TITLE
ISSUE-21: Index all pages (not just blog pages)

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -8,7 +8,7 @@ class LinksController < ApplicationController
     else
       Link
     end
-    @links = scope.where("published_at IS NOT NULL").order(published_at: "DESC")
+    @links = scope.order("published_at DESC NULLS LAST")
   end
 
   # GET /links/1

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -8,7 +8,9 @@ class Link < ApplicationRecord
 
   class << self
     def find_urls(sitemap)
-      sitemap.to_a.select {|x| x.end_with? ".html" }.reject {|x| x.include?("page") || x.include?("/tags/") || x.include?("author") }
+      sitemap.to_a.reject do |x|
+        x.match?(/#.+\z/) || x.include?('page') || x.include?('/tags/') || x.include?('author')
+      end
     end
 
     def find_description(page)


### PR DESCRIPTION
Previously we only included links that end with `.html` from the different sitemaps. Now we include all pages.

The same conditions used to exclude some specifig pages from our index has been left in place.
Code: `.reject {|x| x.include?("page") || x.include?("/tags/") || x.include?("author") }`

[This comment](https://github.com/fastruby/librarian/pull/27#issuecomment-1745418779) show all the links that will now be included for fastruby.io for example.

See: https://github.com/fastruby/librarian/issues/21