### PR TITLE
Fix for issue24: Fixed the broken link view

### DIFF
--- a/app/views/links/show.html.erb
+++ b/app/views/links/show.html.erb
@@ -21,7 +21,7 @@
     <h3 class="text-2xl"><%= media_type %></h3>
     <ul class="list-disc">
       <% snippets.each do |snippet| %>
-        <li class="<%= cycle("bg-white", "bg-black") %>"><%= text_area_tag(:ad, snippet.content, size: '50x10') %></li>
+        <li class="bg-white"><%= text_area_tag(:ad, snippet.content, size: '50x6') %></li>
       <% end %>
     </ul>
   <% end %>


### PR DESCRIPTION
This is the fix for the #24 .

Screenshot before the fix:
<img width="1283" alt="Screenshot 2023-10-12 at 9 05 10 AM" src="https://github.com/fastruby/librarian/assets/946527/768f39ea-f4d0-4a4e-a2f1-fcfd51f91a03">


Screenshot: after the fix
<img width="1276" alt="Screenshot 2023-10-12 at 9 03 27 AM" src="https://github.com/fastruby/librarian/assets/946527/cff3d0ee-5840-431b-bf77-58b8d6198159">
