### PR TITLE
Fix: display raw token after creation

### DIFF
--- a/app/views/personal_access_tokens/index.html.erb
+++ b/app/views/personal_access_tokens/index.html.erb
@@ -1,9 +1,9 @@
 <p style="color: green"><%= notice %></p>
 
-<% if flash[:raw_token].present? %>
+<% if @raw_token.present? %>
   <div class="mb-6 p-4 border rounded bg-yellow-50">
     <p class="font-semibold mb-2">Your new token (copy it now — it won't be shown again):</p>
-    <code class="block p-2 bg-white border rounded break-all"><%= flash[:raw_token] %></code>
+    <code class="block p-2 bg-white border rounded break-all"><%= @raw_token %></code>
   </div>
 <% end %>
 


### PR DESCRIPTION
## Summary

- The view at `app/views/personal_access_tokens/index.html.erb` reads `flash[:raw_token]`, but the controller was updated to set `@raw_token` directly (the earlier change addressed a review comment about not carrying the raw token through the session cookie).
- The result: after generating a token, the green "Token created. Copy it now" banner appears, but the actual token is never displayed, so it can't be copied.

This swaps the view to read `@raw_token`, which matches what `PersonalAccessTokensController#create` already sets.

## How to verify

- [ ] Sign in, visit `/personal_access_tokens`, name a token and click "Generate token"
- [ ] Confirm the banner now shows the raw `lib_…` token in a code box
- [ ] Refresh the page and confirm the token is gone (still one-time visibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)