### PR TITLE
Validate utm_* inclusion and add Bluesky to UTM_SOURCES

### DIFF
--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -3,6 +3,7 @@ class Share < ApplicationRecord
 
   UTM_SOURCES = %w[
     Bing
+    Bluesky
     ConvertKit
     Facebook
     Google
@@ -42,6 +43,10 @@ class Share < ApplicationRecord
   ].sort!
 
   validates :utm_source, :utm_campaign, :utm_medium, :utm_term, presence: true
+  validates :utm_source,   inclusion: { in: UTM_SOURCES,  allow_blank: true }, on: :create
+  validates :utm_medium,   inclusion: { in: UTM_MEDIUMS,  allow_blank: true }, on: :create
+  validates :utm_campaign, inclusion: { in: UTM_CAMPAIGN, allow_blank: true }, on: :create
+  validates :utm_content,  inclusion: { in: UTM_CONTENT,  allow_blank: true }, on: :create
 
   def calculated_url
     uri = URI(link.url)

--- a/spec/factories/shares.rb
+++ b/spec/factories/shares.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :share do
     utm_source { 'LinkedIn' }
-    utm_medium { 'community' }
-    utm_campaign { 'campaignOne' }
+    utm_medium { 'Organic' }
+    utm_campaign { 'Blogpromo' }
     utm_term { 'termOne' }
-    utm_content { 'campaignContent' }
+    utm_content { 'Photo' }
     link
   end
 end

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Share do
+  before do
+    allow_any_instance_of(Link).to receive(:fetch_social_media_snippets).and_return([])
+  end
+
   describe "#valid?" do
     context "when it does not have a link or the minimum requirements" do
       it "is not valid" do

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -5,9 +5,63 @@ RSpec.describe Share do
     context "when it does not have a link or the minimum requirements" do
       it "is not valid" do
         link = Share.new
-        
+
         expect(link.valid?).to be_falsey
         expect(link.errors.full_messages).to eq ["Link must exist", "Utm source can't be blank", "Utm campaign can't be blank", "Utm medium can't be blank", "Utm term can't be blank"]
+      end
+    end
+
+    context "on create with an unrecognized utm_source" do
+      it "is not valid" do
+        share = build(:share, utm_source: "NotARealSource")
+
+        expect(share.valid?(:create)).to be_falsey
+        expect(share.errors[:utm_source]).to include("is not included in the list")
+      end
+    end
+
+    context "on create with Bluesky as utm_source" do
+      it "is valid" do
+        share = build(:share, utm_source: "Bluesky")
+
+        expect(share.valid?(:create)).to be_truthy
+      end
+    end
+
+    context "on create with an unrecognized utm_medium" do
+      it "is not valid" do
+        share = build(:share, utm_medium: "community")
+
+        expect(share.valid?(:create)).to be_falsey
+        expect(share.errors[:utm_medium]).to include("is not included in the list")
+      end
+    end
+
+    context "on create with an unrecognized utm_campaign" do
+      it "is not valid" do
+        share = build(:share, utm_campaign: "campaignOne")
+
+        expect(share.valid?(:create)).to be_falsey
+        expect(share.errors[:utm_campaign]).to include("is not included in the list")
+      end
+    end
+
+    context "on create with an unrecognized utm_content" do
+      it "is not valid" do
+        share = build(:share, utm_content: "Custom")
+
+        expect(share.valid?(:create)).to be_falsey
+        expect(share.errors[:utm_content]).to include("is not included in the list")
+      end
+    end
+
+    context "when updating an existing record whose utm_source is no longer in the list" do
+      it "is allowed (validations are :create-only)" do
+        share = create(:share)
+        share.update_column(:utm_source, "LegacyValue")
+
+        share.shortened_url = "https://example.com/abc"
+        expect(share.save).to be_truthy
       end
     end
   end

--- a/spec/requests/api_links_spec.rb
+++ b/spec/requests/api_links_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe 'JSON API for links and shares', type: :request do
       fastruby_link.social_media_snippets.create!(content: 'Tweet 1', social_media_type: 'Twitter')
       fastruby_link.social_media_snippets.create!(content: 'LI 1',    social_media_type: 'LinkedIn')
       fastruby_link.shares.create!(
-        utm_source: 'LinkedIn', utm_medium: 'community',
-        utm_campaign: 'campaignOne', utm_term: 'termOne'
+        utm_source: 'LinkedIn', utm_medium: 'Organic',
+        utm_campaign: 'Blogpromo', utm_term: 'termOne'
       )
     end
 
@@ -104,8 +104,8 @@ RSpec.describe 'JSON API for links and shares', type: :request do
   describe 'GET /links/:link_id/shares.json' do
     let!(:share) do
       fastruby_link.shares.create!(
-        utm_source: 'LinkedIn', utm_medium: 'community',
-        utm_campaign: 'campaignOne', utm_term: 'termOne'
+        utm_source: 'LinkedIn', utm_medium: 'Organic',
+        utm_campaign: 'Blogpromo', utm_term: 'termOne'
       )
     end
 
@@ -140,8 +140,8 @@ RSpec.describe 'JSON API for links and shares', type: :request do
       {
         share: {
           utm_source: 'LinkedIn',
-          utm_medium: 'community',
-          utm_campaign: 'campaignOne',
+          utm_medium: 'Organic',
+          utm_campaign: 'Blogpromo',
           utm_term: 'termOne',
           utm_content: 'Photo'
         }


### PR DESCRIPTION
## Summary
- Add `Bluesky` to `Share::UTM_SOURCES` so it appears in the dropdown and is accepted by the JSON create endpoint
- Add inclusion validations for `utm_source`, `utm_medium`, `utm_campaign`, and `utm_content`, scoped to `:create`
- Update the factory and existing request-spec setups to use values that are in the whitelist
- Add Share model specs covering each new validation, Bluesky as a valid `utm_source`, and the `:create`-only contract

## Why

The UTM constants existed but were only dropdown options. The new JSON API (and the original HTML form) would happily accept any string. This PR makes the constants the source of truth for new shares so typos and out-of-list values are caught at creation time.

`on: :create` keeps the new validations strict for new records while leaving existing rows untouched. The controller's `assign_shortened_url` flow does an `update` immediately after create, which won't be re-validated.

## Test plan
- [x] `bundle exec rspec spec/models/share_spec.rb`
- [x] `bundle exec rspec spec/requests/api_links_spec.rb`
- [x] `bundle exec rspec spec/controllers/shares_controller_spec.rb`
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)